### PR TITLE
Setup autodocs with sphinx-apidoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import os
 # sys.path.insert(0, os.path.abspath('.'))
 
 # autodoc needs to find our code.
-sys.path.insert(0, os.path.abspath("../rundmcmc/"))
+sys.path.insert(0, os.path.abspath("../"))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ RunDMCMC
     :maxdepth: 2
     :caption: Contents:
 
+    modules
+
 This is the documentation for RunDMCMC, a project to randomly sample from valid
 congressional district plans using Markov Chain Monte Carlo. The project is
 hosted in the `Gerrymandr/RunDMCMC <https://github.com/gerrymandr/RunDMCMC>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,6 @@ RunDMCMC
     :maxdepth: 2
     :caption: Contents:
 
-    models
-
 This is the documentation for RunDMCMC, a project to randomly sample from valid
 congressional district plans using Markov Chain Monte Carlo. The project is
 hosted in the `Gerrymandr/RunDMCMC <https://github.com/gerrymandr/RunDMCMC>`_

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,7 +1,0 @@
-models module
-=============
-
-.. automodule:: models
-    :members:
-    :undoc-members:
-    :private-members:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -5,6 +5,5 @@ RunDMCMC
    :maxdepth: 4
 
    rundmcmc
-   setup
    tests
    versioneer

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,10 @@
+RunDMCMC
+========
+
+.. toctree::
+   :maxdepth: 4
+
+   rundmcmc
+   setup
+   tests
+   versioneer

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -6,4 +6,3 @@ RunDMCMC
 
    rundmcmc
    tests
-   versioneer

--- a/docs/rundmcmc.rst
+++ b/docs/rundmcmc.rst
@@ -1,0 +1,46 @@
+rundmcmc package
+================
+
+Submodules
+----------
+
+rundmcmc.cli module
+-------------------
+
+.. automodule:: rundmcmc.cli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rundmcmc.ingest module
+----------------------
+
+.. automodule:: rundmcmc.ingest
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rundmcmc.make_graph module
+--------------------------
+
+.. automodule:: rundmcmc.make_graph
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rundmcmc.models module
+----------------------
+
+.. automodule:: rundmcmc.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: rundmcmc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,0 +1,7 @@
+setup module
+============
+
+.. automodule:: setup
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,7 +1,0 @@
-setup module
-============
-
-.. automodule:: setup
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -1,0 +1,30 @@
+tests package
+=============
+
+Submodules
+----------
+
+tests.test_cli module
+---------------------
+
+.. automodule:: tests.test_cli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tests.test_models module
+------------------------
+
+.. automodule:: tests.test_models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tests
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
These commits get the sphinx docs in a more functional state with autodoc. Most importantly, the `.rst` files were autogenerated with `sphinx-apidoc`.