### PR TITLE
Compute shared perimeters, streamline ingestion

### DIFF
--- a/rundmcmc/ingest.py
+++ b/rundmcmc/ingest.py
@@ -35,4 +35,3 @@ def ingest(filepath, name_of_geoid_col):
 
 if __name__ == "__main__":
     ingest("testData/testData.shp", "CD")
-    

--- a/rundmcmc/ingest.py
+++ b/rundmcmc/ingest.py
@@ -23,8 +23,8 @@ def ingest(filepath, name_of_geoid_col):
 
         for n in neighbors[shape]:
             shared_perims[shape].append(
-                df.loc[shape, 'geometry'].intersection(
-                    df.loc[n, 'geometry']).length)
+                df.loc[shape, "geometry"].intersection(
+                    df.loc[n, "geometry"]).length)
 
     sorted_keys = sorted(neighbors)
 

--- a/rundmcmc/ingest.py
+++ b/rundmcmc/ingest.py
@@ -16,18 +16,18 @@ def ingest(filepath, name_of_geoid_col):
     neighbors = ps.weights.Rook.from_dataframe(df, geom_col="geometry").neighbors
     for n in neighbors:
         neighbors[n] = sorted(neighbors[n])
-        
+
     shared_perims = {}
     for shape in neighbors.keys():
         shared_perims[shape] = []
-        
+
         for n in neighbors[shape]:
             shared_perims[shape].append(
                 df.loc[shape, 'geometry'].intersection(
                     df.loc[n, 'geometry']).length)
-    
+
     sorted_keys = sorted(neighbors)
-    
+
     return ([neighbors[i] for i in sorted_keys],
             [shared_perims[i] for i in sorted_keys],
             [df.loc[i, name_of_geoid_col] for i in sorted_keys])
@@ -35,3 +35,4 @@ def ingest(filepath, name_of_geoid_col):
 
 if __name__ == "__main__":
     ingest("testData/testData.shp", "CD")
+    

--- a/rundmcmc/ingest.py
+++ b/rundmcmc/ingest.py
@@ -18,19 +18,20 @@ def ingest(filepath, name_of_geoid_col):
         neighbors[n] = sorted(neighbors[n])
 
     shared_perims = {}
-    for shape in neighbors.keys():
+    for shape in neighbors:
         shared_perims[shape] = []
 
         for n in neighbors[shape]:
             shared_perims[shape].append(
                 df.loc[shape, "geometry"].intersection(
-                    df.loc[n, "geometry"]).length)
+                    df.loc[n, "geometry"])
+                .length)
 
     sorted_keys = sorted(neighbors)
 
-    return ([neighbors[i] for i in sorted_keys],
-            [shared_perims[i] for i in sorted_keys],
-            [df.loc[i, name_of_geoid_col] for i in sorted_keys])
+    return([neighbors[i] for i in sorted_keys],
+           [shared_perims[i] for i in sorted_keys],
+           [df.loc[i, name_of_geoid_col] for i in sorted_keys])
 
 
 if __name__ == "__main__":

--- a/rundmcmc/ingest.py
+++ b/rundmcmc/ingest.py
@@ -5,47 +5,32 @@ import geopandas as gp
 def ingest(filepath, name_of_geoid_col):
     """
         Reads in a shapefile through PySAL, and generates an
-        adjacency matrix (rook adjacency). Then, load the converted
-        NumPy data from PySAL into NetworkX.
+        adjacency list (rook adjacency). Then, compute shared
+        perimeters for all adjacent shapes.
 
         :filepath: Filepath to input shapefile location.
     """
     df = gp.read_file(filepath)
 
-    # Iterate over rows from dataframe and assign perimeters.
-    for i, _ in df.iterrows():
-        poly = df.loc[i, "geometry"]
-        df.loc[i, "perimeter"] = poly.length
-
-    # Generate rook neighbor adjacency matrix from dataframe.
-    shp = ps.weights.Rook.from_dataframe(df, geom_col="geometry")
-
-    # See http://bit.ly/2y3HNMh
-    adjacency = shp.full()[0].tolist()
-    perims = []
-    neighbors = []
-
-    # Iterate over adjacency matrix
-    for i, _ in enumerate(adjacency):
-        row = []
-        for j, _ in enumerate(adjacency):
-            adj = adjacency[i][j]
-
-            # If block i is adjacent to block j, append their shared perimeter
-            # to the list of perimeters; additionally, change the [i][j]th matrix
-            # entry to j (to represent actual adjacency).
-            if adj == 1:
-                row.append(df["perimeter"][j])
-                adjacency[i][j] = int(j)
-
-        perims.append(row)
-
-    # Strip out zeros from adjacency list.
-    for row in adjacency:
-        neighbors.append([i for i in row if isinstance(i, int)])
-
-    for i, j in enumerate(neighbors):
-        return neighbors, perims, list(df[name_of_geoid_col])
+    # Generate rook neighbor lists from dataframe.
+    neighbors = ps.weights.Rook.from_dataframe(df, geom_col="geometry").neighbors
+    for n in neighbors:
+        neighbors[n] = sorted(neighbors[n])
+        
+    shared_perims = {}
+    for shape in neighbors.keys():
+        shared_perims[shape] = []
+        
+        for n in neighbors[shape]:
+            shared_perims[shape].append(
+                df.loc[shape, 'geometry'].intersection(
+                    df.loc[n, 'geometry']).length)
+    
+    sorted_keys = sorted(neighbors)
+    
+    return ([neighbors[i] for i in sorted_keys],
+            [shared_perims[i] for i in sorted_keys],
+            [df.loc[i, name_of_geoid_col] for i in sorted_keys])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, ingest was unnecessarily unpacking the pysal weights into an adjacency matrix, but it is conveniently already provided in a dictionary. So I streamlined it.

More importantly, the previous version was not actually computing the shared perimeters between neighbors, but just listing the full perimeter of each shape.

I’ve made it so the output is identical to before (with the corrected shared perimeter values), but I think that the sorting is unnecessary and that the plain neighbors and shared_perims dicts could be handed off to the networkx generation function in their original form, and that integer IDs could be assigned there. Probably doesn’t matter much, but you could potentially have an indexing headache somewhere.