### PR TITLE
Add a special single-flip-contiguity check

### DIFF
--- a/rundmcmc/partition.py
+++ b/rundmcmc/partition.py
@@ -42,10 +42,12 @@ class Partition:
     :assignment: dictionary mapping nodes to their assigned parts of the partition
     """
 
-    def __init__(self, graph, assignment, aggregate_fields=None, overwrite_stats=None):
+    def __init__(self, graph, assignment, aggregate_fields=None,
+                 overwrite_stats=None, changed_assignments=None):
         self.graph = graph
         self.assignment = assignment
         self.cut_edges = [edge for edge in self.graph.edges if self.crosses_parts(edge)]
+        self.changed_assignments = changed_assignments
 
         if aggregate_fields:
             self.statistics = {field: dict() for field in aggregate_fields}
@@ -70,12 +72,14 @@ class Partition:
         :flips: a dictionary of nodes mapped to their new assignments
         :return: a new Partition instance
         """
+        changed_assignments = {node: self.assignment[node] for node in flips.keys()}
         new_assignment = {**self.assignment, **flips}
 
         new_stats = {field: self.update_statistic(
             flips, statistic, field) for field, statistic in self.statistics.items()}
 
-        return Partition(self.graph, new_assignment, overwrite_stats=new_stats)
+        return Partition(self.graph, new_assignment, overwrite_stats=new_stats,
+                         changed_assignments=changed_assignments)
 
     def initialize_statistic(self, field):
         """

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -43,7 +43,6 @@ def single_flip_contiguous(partition):
 
     """
     graph = partition.graph
-    old_assignments = partition.changed_assignments
     assignment_dict = partition.assignment
 
     def partition_edge_weight(start_node, end_node, edge_attrs):
@@ -57,8 +56,6 @@ def single_flip_contiguous(partition):
         return 1
 
     for change_node, old_assignment in partition.changed_assignments.items():
-        new_assignment = assignment_dict[change_node]
-
         old_neighbors = []
         for node in graph.neighbors(change_node):
             if assignment_dict[node] == old_assignment:

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -65,9 +65,10 @@ def single_flip_contiguous(partition):
 
         for neighbor in old_neighbors:
             try:
-                nx_path.single_source_dijkstra(graph, start_neighbor, neighbor,
-                                               cutoff=5,
-                                               weight=partition_edge_weight)
+                distance, _ = nx_path.single_source_dijkstra(graph, start_neighbor, neighbor,
+                                                             weight=partition_edge_weight)
+                if not (distance < float("inf")):
+                    return False
             except NetworkXNoPath as e:
                 return False
 

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -32,8 +32,7 @@ def single_flip_contiguous(partition):
     Check if swapping the given node from its old assignment disconnects the
     old assignment class.
 
-    :removed_node: Node id.
-    :old_assignment: The assignment class that the node was removed from.
+    :parition: :class:`.Partition` object.
     :returns: Boolean.
 
     We assume that `removed_node` belonged to an assignment class that formed a


### PR DESCRIPTION
This implements a (potentially) more efficient contiguity check for single node flips, and modifies the relevant classes to make this possible. __No immediate functionality is changed__; i.e., nothing should break by merging this.

Performance seems moderately improved in some cases. Profiling is needed to determine the full impact. Runtime seems roughly linear in number of steps.

### Method
Given a connected graph, removing an arbitrary vertex yields a connected graph iff the neighbors of that vertex are pairwise connected in the resulting graph. This translates fairly directly to our problem and avoids checking that every district subgraph is connected. The code is an implementation of checking the neighbors for pairwise connectedness.

### Important changes
The `Partition` class now takes a `changed_assignments` argument. This is a dictionary of `(nodeid, assignment)` pairs that represent the old assignments _before_ they were changed. This way, later methods can pinpoint what exactly on the graph has changed from one step to the other.