### PR TITLE
Fix C dependency issues with RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,11 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-# -- Path setup --------------------------------------------------------------
-
 import sys
 import os
+from unittest.mock import MagicMock
+
+# -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -163,5 +164,19 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+# -- Mock C libraries --------------------------------------------------------
+
+# RTD is unable to install libraries with C dependencies.
+# Using the fix from here: http://docs.readthedocs.io/en/latest/faq.html?#i-get-import-errors-on-libraries-that-depend-on-c-modules
+
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+
+MOCK_MODULES = ["numpy", "pandas", "geopandas", "pysal", "matplotlib"]
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,7 +176,7 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ["numpy", "pandas", "geopandas", "pysal", "matplotlib"]
+MOCK_MODULES = ["numpy", "pandas", "geopandas", "pysal", "matplotlib", "networkx"]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,7 @@ texinfo_documents = [
 # -- Mock C libraries --------------------------------------------------------
 
 # RTD is unable to install libraries with C dependencies.
-# Using the fix from here: http://docs.readthedocs.io/en/latest/faq.html?#i-get-import-errors-on-libraries-that-depend-on-c-modules
+# Using the fix from here: http://docs.readthedocs.io/en/latest/faq.html
 
 
 class Mock(MagicMock):


### PR DESCRIPTION
RTD can't handle arbitrary C libraries. This mocks the those so that RTD can import our files and correctly autobuild docs.