### PR TITLE
Fixed some bugs, and implemented cut_edges_by_part

### DIFF
--- a/rundmcmc/updaters.py
+++ b/rundmcmc/updaters.py
@@ -105,7 +105,7 @@ class Tally:
         """
         tally = collections.defaultdict(self.dtype)
         for node, part in partition.assignment.items():
-            tally[part] += self._get_tally_from_node(partition.graph, node, self.fields)
+            tally[part] += self._get_tally_from_node(partition, node)
         return tally
 
     def _update_tally(self, partition):

--- a/rundmcmc/updaters.py
+++ b/rundmcmc/updaters.py
@@ -2,24 +2,64 @@ import collections
 import math
 
 
+def touches_part(edge, part, partition):
+    return partition.assignment[edge[0]] == part or partition.assignment[edge[1]] == part
+
+
+def put_edges_into_parts(edges, assignment):
+    by_part = collections.defaultdict(set)
+    for edge in edges:
+        # add edge to the sets corresponding to the parts it touches
+        by_part[assignment[edge[0]]].add(edge)
+        by_part[assignment[edge[1]]].add(edge)
+    return by_part
+    # return {part: {tuple(sorted(edge)) for edge in edges if touches_part(edge, part, partition)}
+    #        for part in partition.parts}
+
+
+def new_cuts(partition):
+    """The edges that were not cut, but now are"""
+    return {tuple(sorted((node, neighbor))) for node in partition.flips
+            for neighbor in partition.graph[node]
+            if partition.crosses_parts((node, neighbor))}
+
+
+def obsolete_cuts(partition):
+    """The edges that were cut, but now are not"""
+    return {tuple(sorted((node, neighbor))) for node in partition.flips
+            for neighbor in partition.graph.neighbors(node)
+            if partition.parent.crosses_parts((node, neighbor)) and
+            not partition.crosses_parts((node, neighbor))}
+
+
+def cut_edges_by_part(partition, alias='cut_edges'):
+    if not partition.parent:
+        edges = {tuple(sorted(edge)) for edge in partition.graph.edges
+                if partition.crosses_parts(edge)}
+        return put_edges_into_parts(edges, partition.assignment)
+
+    new_by_part = put_edges_into_parts(new_cuts(partition), partition.assignment)
+    obsolete_by_part = put_edges_into_parts(obsolete_cuts(partition), partition.parent.assignment)
+
+    new_cut_edges = collections.defaultdict(set)
+    previous_value = partition.parent[alias]
+    for part in partition.parts:
+        new_cut_edges[part] = (previous_value[part] | new_by_part[part]) - obsolete_by_part[part]
+    return new_cut_edges
+
+
 def cut_edges(partition):
     parent = partition.parent
-    flips = partition.flips
+
     if not parent:
         return {edge for edge in partition.graph.edges
                 if partition.crosses_parts(edge)}
     # Edges that weren't cut, but now are cut
     # We sort the tuples to make sure we don't accidentally end
-    # up with both (4,5) and (5,4) (e.g.) in it
-    new_cuts = {tuple(sorted((node, neighbor))) for node in flips
-            for neighbor in partition.graph[node]
-            if partition.crosses_parts((node, neighbor))}
-    # Edges that were cut, but now are not
-    obsolete_cuts = {tuple(sorted((node, neighbor))) for node in flips
-            for neighbor in partition.graph[node]
-            if not partition.crosses_parts((node, neighbor))}
+    # up with both (4,5) and (5,4) (for example) in it
+    new, obsolete = new_cuts(partition), obsolete_cuts(partition)
 
-    return (parent['cut_edges'] | new_cuts) - obsolete_cuts
+    return (parent['cut_edges'] | new) - obsolete
 
 
 class Proportion:

--- a/rundmcmc/updaters.py
+++ b/rundmcmc/updaters.py
@@ -13,8 +13,6 @@ def put_edges_into_parts(edges, assignment):
         by_part[assignment[edge[0]]].add(edge)
         by_part[assignment[edge[1]]].add(edge)
     return by_part
-    # return {part: {tuple(sorted(edge)) for edge in edges if touches_part(edge, part, partition)}
-    #        for part in partition.parts}
 
 
 def new_cuts(partition):

--- a/tests/test_updaters.py
+++ b/tests/test_updaters.py
@@ -42,9 +42,6 @@ def test_implementation_of_cut_edges_matches_naive_method():
     naive_cut_edges = {edge for edge in graph.edges
                        if new_partition.crosses_parts(edge)}
 
-    print(result)
-    print(naive_cut_edges)
-
     assert edge_set_equal(result, naive_cut_edges)
 
 
@@ -185,3 +182,21 @@ def test_vote_proportions_sum_to_one():
     partition = setup_for_proportion_updaters(['D', 'R'])
 
     assert all(abs(1 - partition['D%'][i] - partition['R%'][i]) < 0.001 for i in partition['D%'])
+
+
+def test_cut_edges_doesnt_duplicate_edges_with_different_order_of_nodes():
+    graph = three_by_three_grid()
+    assignment = {0: 1, 1: 1, 2: 2, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2}
+    updaters = {'cut_edges': cut_edges}
+    partition = Partition(graph, assignment, updaters)
+    # 112    111
+    # 112 -> 121
+    # 222    222
+    flip = {4: 2, 2: 1, 5: 1}
+
+    new_partition = Partition(parent=partition, flips=flip)
+
+    result = new_partition['cut_edges']
+
+    for edge in result:
+        assert (edge[1], edge[0]) not in result


### PR DESCRIPTION
- `cut_edges_by_part` returns a dictionary from districts to the set of edges from that district to other districts. This will be helpful in implementing perimeter updaters and Polsby-Popper. Closes #74 .
- Fixed some bugs in the existing cut_edges. Basically, any time we manipulate sets of edges we need to use `tuple(sorted(edge))` instead of `edge`, to make sure we don't accidentally have two copies of the same edge (with just different orders of nodes) in the set. Would it be worth it to implement an edge set class that does this for you?