### PR TITLE
run chain with rundmcmc config.ini

### DIFF
--- a/rundmcmc/__init__.py
+++ b/rundmcmc/__init__.py
@@ -1,3 +1,4 @@
+from .__main__ import main
 from ._version import get_versions
 
 __version__ = get_versions()['version']

--- a/rundmcmc/__init__.py
+++ b/rundmcmc/__init__.py
@@ -1,4 +1,3 @@
-from .__main__ import main
 from ._version import get_versions
 
 __version__ = get_versions()['version']

--- a/rundmcmc/__main__.py
+++ b/rundmcmc/__main__.py
@@ -2,7 +2,12 @@ import sys
 from rundmcmc.parse_config import read_basic_config
 
 
-def main(args = sys.argv):
+def main(args):
+    if not args:
+        args = sys.argv
+    if len(args) < 1:
+        raise ValueError("no config file provided")
+
     chain, chain_func, scores, output_func, output_type = read_basic_config(args[1])
     print("setup the chain")
 
@@ -13,4 +18,4 @@ def main(args = sys.argv):
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv)

--- a/rundmcmc/__main__.py
+++ b/rundmcmc/__main__.py
@@ -2,8 +2,8 @@ import sys
 from rundmcmc.parse_config import read_basic_config
 
 
-def main(arg):
-    chain, chain_func, scores, output_func, output_type = read_basic_config(arg)
+def main(args = sys.argv):
+    chain, chain_func, scores, output_func, output_type = read_basic_config(args[1])
     print("setup the chain")
 
     output = chain_func(chain)
@@ -13,4 +13,4 @@ def main(arg):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1])
+    main()


### PR DESCRIPTION
* Can run chain outside of rundmcmc folder
* Can output directly into the folder you want
* Don't need to call `__main__` directly. Instead `rundmcmc config.ini`