### PR TITLE
Add big, bold links to docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,10 @@ the space around an initial districting plan to give some idea of the degree of
 gerrymandering. It is a Python rewrite of the chain C++ program
 (https://github.com/gerrymandr/cfp_mcmc), originally by Maria Chikina, Alan
 Frieze and Wesley Pegden, for their paper, "Assessing significance in a Markov
-chain without mixing" (http://www.pnas.org/content/114/11/2860)
+chain without mixing" (http://www.pnas.org/content/114/11/2860).
+
+- **Website (with documentation):** https://rundmcmc.readthedocs.io/en/latest/
+- **Bug reports:** https://github.com/gerrymandr/RunDMCMC/issues
 
 
 Installation


### PR DESCRIPTION
We've had some complaints about the RTD badge being too easy to miss. You can't miss big, bold links!