### PR TITLE
1, 2, and 3+ histogram subplots now work

### DIFF
--- a/rundmcmc/vis_output.py
+++ b/rundmcmc/vis_output.py
@@ -14,7 +14,7 @@ def hist_of_table_scores(table, scores=None, outputFile="output.png"):
     numrows = max(numrows, 1)
     numcols = max(numcols, 1)
     _, axes = plt.subplots(nrows=numrows, ncols=numcols, squeeze=False)
-    plt.subplots_adjust(wspace=.2,hspace=.4)
+    plt.subplots_adjust(wspace=.2, hspace=.4)
 
     if numcols == 1:
         axes = axes.flatten()

--- a/rundmcmc/vis_output.py
+++ b/rundmcmc/vis_output.py
@@ -13,9 +13,11 @@ def hist_of_table_scores(table, scores=None, outputFile="output.png"):
     numcols = int(len(scores) / numrows)
     numrows = max(numrows, 1)
     numcols = max(numcols, 1)
-    _, axes = plt.subplots(nrows=numrows, ncols=numcols)
+    _, axes = plt.subplots(nrows=numrows, ncols=numcols, squeeze=False)
+    plt.subplots_adjust(wspace=.2,hspace=.4)
 
     if numcols == 1:
+        axes = axes.flatten()
         quadrants = {key: i for i, key in enumerate(scores.keys())}
     else:
         quadrants = {


### PR DESCRIPTION
Previously running a single histogram would crash the output. Now automatically flattens the subplot list if there is a single column so that quadrant works and has squeeze=False so that we still get a 2d array if there are two plots. 

Also added some spacing so the titles don't collide with the x labels. 