### PR TITLE
Fixed L1 polsby popper bug, add L^{-1}

### DIFF
--- a/rundmcmc/generate_config.py
+++ b/rundmcmc/generate_config.py
@@ -39,7 +39,7 @@ proposal = ""
 accept = ""
 cFileName = ''
 validOptions = [
-    "L1_reciprocal_polsby_popper",
+    "no_worse_L1_reciprocal_polsby_popper",
     "within_percent_of_ideal_population",
     "fast_connected",
     "refuse_new_splits",
@@ -49,7 +49,7 @@ evalOptions = [
     "efficiency_gap",
     "mean_median",
     "mean_thirdian",
-    "L1_reciprocal_polsby_popper",
+    "no_worse_L1_reciprocal_polsby_popper",
     "normalized_efficiency_gap",
 ]
 propOptions = [

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -8,8 +8,24 @@ from networkx import NetworkXNoPath
 from rundmcmc.updaters import CountySplit
 
 
+class SelfConfiguringUpperBound:
+    def __init__(self, func):
+        self.func = func
+        self.bound = None
+
+    def __call__(self, partition):
+        if not self.bound:
+            self.bound = self.func(partition)
+            return True
+        else:
+            return self.func(partition) <= self.bound
+
+
 def L1_reciprocal_polsby_popper(partition):
     return sum(1 / value for value in partition['polsby_popper'].values())
+
+
+no_worse_L1_reciprocal_polsby_popper = SelfConfiguringUpperBound(L1_reciprocal_polsby_popper)
 
 
 def L1_reciprocal_discrete_polsby_popper(partition):


### PR DESCRIPTION
Now the constraint is called 'no_worse_L1_polsby_popper'.

I also added the L^{-1} polsby popper score/constraint.