### PR TITLE
Added tolerance for validity functions based on original districting plan

### DIFF
--- a/rundmcmc/generate_config.py
+++ b/rundmcmc/generate_config.py
@@ -299,18 +299,18 @@ def clear_proposaldata(event):
 
 def add_to_validlist():
     global validMenuFuncs, vfuncs, oldH, oldS
-    hard='hard_limit'
-    soft='within_percent_of_original'
+    hard = 'hard_limit'
+    soft = 'within_percent_of_original'
 
     # get list of all constraints added (hard or soft keys have different types)
     hardKeysOfInterest = [x for x in validOptions if validMenuFuncs[x][hard].get()]
-    softKeysOfInterest = [','.join([x, str(y)]) for x in validOptions 
+    softKeysOfInterest = [','.join([x, str(y)]) for x in validOptions
                 for y, z in validMenuFuncs[x][soft].items() if z.get()]
 
-    # compare with previously recorded constraints to delete 
+    # compare with previously recorded constraints to delete
     newFuncNames = hardKeysOfInterest + [x.split(',')[0] for x in softKeysOfInterest]
     obsoleteSFuncs = [y for y in oldS if newFuncNames.count(y.split(',')[0]) > 1]
-    obsoleteHFuncs = [y for y in oldH if newFuncNames.count(y              ) > 1]
+    obsoleteHFuncs = [y for y in oldH if newFuncNames.count(y) > 1]
 
     # now update the menu items
     for y in obsoleteHFuncs:
@@ -419,7 +419,7 @@ numstepsdata.place(relx=0.3 + offset, rely=0, relheight=1)
 VALIDF = tk.Frame(SCORING)
 VALIDF.place(relx=offset, rely=.25 + offset, relwidth=1 - 2 * offset, relheight=.1)
 validators = tk.Menubutton(VALIDF, text="Constraints", indicatoron=True, width=20)
-valid_menu=tk.Menu(validators, tearoff=False)
+valid_menu = tk.Menu(validators, tearoff=False)
 validators.configure(menu=valid_menu)
 percent_menu = tk.Menu(valid_menu, tearoff=False)
 
@@ -430,7 +430,7 @@ for item in validOptions:
     menu = tk.Menu(valid_menu, tearoff=False)
     valid_menu.add_cascade(label=item, menu=menu)
 
-    # add check option for a hard limit 
+    # add check option for a hard limit
     validMenuFuncs[item]['hard_limit'] = tk.BooleanVar(value=False)
     menu.add_checkbutton(label='hard_limit',
             variable=validMenuFuncs[item]['hard_limit'],

--- a/rundmcmc/generate_config.py
+++ b/rundmcmc/generate_config.py
@@ -108,7 +108,7 @@ def callback():
 
     # VALIDITY
     if len(vfuncs) > 0:
-        config['VALIDITY'] = {"col" + str(i): vfuncs[i] for i in range(len(vfuncs))}
+        config['VALIDITY'] = {"col" + x: x for x in validlist.get().split(';')}
 
     # EVALUATION SCORES
     if len(efuncs) > 0:

--- a/rundmcmc/generate_config.py
+++ b/rundmcmc/generate_config.py
@@ -41,11 +41,19 @@ cFileName = ''
 validOptions = [
     "no_worse_L1_reciprocal_polsby_popper",
     "no_worse_L_minus_1_polsby_popper",
-    "within_percent_of_ideal_population",
     "fast_connected",
     "refuse_new_splits",
-    "no_vanishing_districts"
+    "no_vanishing_districts",
+    "L1_reciprocal_polsby_popper",
+    "population_balance"
 ]
+percents = [0, 1, 2, 5, 10]
+validMenuFuncs = {x: {
+    "hard_limit": False,
+    "within_percent_of_original": {z: False for z in percents}
+    } for x in validOptions}
+oldH = []
+oldS = []
 evalOptions = [
     "efficiency_gap",
     "mean_median",
@@ -289,14 +297,42 @@ def clear_proposaldata(event):
     proposaldata.delete(0, tk.END)
 
 
-def add_to_validlist(event):
-    global vfuncs
-    newfunc = validvar.get()
-    if (newfunc not in vfuncs) and (newfunc != "VALIDATORS"):
-        validlist.configure(state="normal")
-        validlist.insert(tk.END, str(newfunc) + ",")
-        validlist.configure(state="disabled")
-        vfuncs.append(newfunc)
+def add_to_validlist():
+    global validMenuFuncs, vfuncs, oldH, oldS
+    hard='hard_limit'
+    soft='within_percent_of_original'
+
+    # get list of all constraints added (hard or soft keys have different types)
+    hardKeysOfInterest = [x for x in validOptions if validMenuFuncs[x][hard].get()]
+    softKeysOfInterest = [','.join([x, str(y)]) for x in validOptions 
+                for y, z in validMenuFuncs[x][soft].items() if z.get()]
+
+    # compare with previously recorded constraints to delete 
+    newFuncNames = hardKeysOfInterest + [x.split(',')[0] for x in softKeysOfInterest]
+    obsoleteSFuncs = [y for y in oldS if newFuncNames.count(y.split(',')[0]) > 1]
+    obsoleteHFuncs = [y for y in oldH if newFuncNames.count(y              ) > 1]
+
+    # now update the menu items
+    for y in obsoleteHFuncs:
+        validMenuFuncs[y][hard] = tk.BooleanVar(value=False)
+    for y in obsoleteSFuncs:
+        validMenuFuncs[y.split(',')[0]][soft][y.split(',')[1]] = tk.BooleanVar(value=False)
+
+    # only keep the items of interest for text entry box
+    hardKeysOfInterest = [x for x in hardKeysOfInterest if x not in obsoleteHFuncs]
+    softKeysOfInterest = [x for x in softKeysOfInterest if x not in obsoleteSFuncs]
+
+    # update running tally of selected items
+    oldH = [x for x in hardKeysOfInterest]
+    oldS = [x for x in softKeysOfInterest]
+    allfuncs = [x for x in hardKeysOfInterest + softKeysOfInterest]
+
+    # add to the tet entry box
+    validlist.configure(state="normal")
+    validlist.delete(0, tk.END)
+    validlist.insert(0, ";".join(allfuncs))
+    validlist.configure(state="disabled")
+    vfuncs = [x for x in allfuncs]
 
 
 def add_to_evallist():
@@ -382,10 +418,37 @@ numstepsdata.place(relx=0.3 + offset, rely=0, relheight=1)
 
 VALIDF = tk.Frame(SCORING)
 VALIDF.place(relx=offset, rely=.25 + offset, relwidth=1 - 2 * offset, relheight=.1)
-validvar = tk.StringVar(value="Constraints")
-validators = tk.OptionMenu(VALIDF, validvar, *validOptions, command=add_to_validlist)
-validators.config(width=20)
+validators = tk.Menubutton(VALIDF, text="Constraints", indicatoron=True, width=20)
+valid_menu=tk.Menu(validators, tearoff=False)
+validators.configure(menu=valid_menu)
+percent_menu = tk.Menu(valid_menu, tearoff=False)
+
+for item in validOptions:
+    # create a menu item for each validity function,
+    # and add a dropdown menu for that function that
+    # specifies hard or soft limit
+    menu = tk.Menu(valid_menu, tearoff=False)
+    valid_menu.add_cascade(label=item, menu=menu)
+
+    # add check option for a hard limit 
+    validMenuFuncs[item]['hard_limit'] = tk.BooleanVar(value=False)
+    menu.add_checkbutton(label='hard_limit',
+            variable=validMenuFuncs[item]['hard_limit'],
+            onvalue=True,
+            offvalue=False,
+            command=add_to_validlist)
+
+    # add dropdown menu for within_percent_of_original that has percent options
+    percentmenu = tk.Menu(menu, tearoff=False)
+    menu.add_cascade(label='within_percent_of_original', menu=percentmenu)
+    for p in percents:
+        validMenuFuncs[item]['within_percent_of_original'][p] = tk.BooleanVar(value=False)
+        percentmenu.add_checkbutton(label=p,
+                variable=validMenuFuncs[item]['within_percent_of_original'][p],
+                command=add_to_validlist)
+
 validators.place(relx=offset, rely=0, relheight=1)
+
 validlist = tk.Entry(VALIDF, width=45)
 validlist.place(relx=0.3 + offset, rely=0, relheight=1)
 

--- a/rundmcmc/generate_config.py
+++ b/rundmcmc/generate_config.py
@@ -96,7 +96,7 @@ def callback():
         # check that any voting data columns were spacified to use
         if len(vfuncs) > 0:
             vcols = vdata.get()
-            if vcols != "names of columns to add, comma separated":
+            if (vcols != "names of columns to add, comma separated") and (vcols != ''):
                 vcols = vcols.split(',')
                 config["VOTE_DATA"] = {"col" + str(x): vcols[x] for x in range(len(vcols))}
 

--- a/rundmcmc/parse_config.py
+++ b/rundmcmc/parse_config.py
@@ -225,8 +225,15 @@ def read_basic_config(configFileName):
     # set up validator functions and create Validator class instance
     validatorsUpdaters = []
     if config.has_section('VALIDITY') and len(list(config['VALIDITY'].keys())) > 0:
-        validators = [getattr(valids, x) for x in config['VALIDITY'].values()]
-        validatorsUpdaters.extend(list(config['VALIDITY'].values()))
+        validators = list(config['VALIDITY'].values())
+        for i, x in enumerate(validators):
+            if len(x.split(',')) == 1:
+                validators[i] = getattr(valids, x)
+            else:
+                [y, z] = x.split(',')
+                validators[i] = valids.WithinPercentRangeOfBounds(getattr(valids, y), z)
+        validatorsUpdaters.extend([ x.split(',')[0] for x in config['VALIDITY'].values()])
+
     validators = valids.Validator(validators)
     # add updaters required by this list of validators to list of updaters
     for x in validatorsUpdaters:

--- a/rundmcmc/parse_config.py
+++ b/rundmcmc/parse_config.py
@@ -232,7 +232,7 @@ def read_basic_config(configFileName):
             else:
                 [y, z] = x.split(',')
                 validators[i] = valids.WithinPercentRangeOfBounds(getattr(valids, y), z)
-        validatorsUpdaters.extend([ x.split(',')[0] for x in config['VALIDITY'].values()])
+        validatorsUpdaters.extend([x.split(',')[0] for x in config['VALIDITY'].values()])
 
     validators = valids.Validator(validators)
     # add updaters required by this list of validators to list of updaters

--- a/rundmcmc/parse_config.py
+++ b/rundmcmc/parse_config.py
@@ -111,6 +111,12 @@ def dependencies(scoreType, POP, AREA):
     elif scoreType == "L_minus_1_polsby_popper":
         depends = dependencies("polsby_popper", POP, AREA)
 
+    elif scoreType == "no_worse_L1_reciprocal_polsby_popper":
+        depends = dependencies("polsby_popper", POP, AREA)
+
+    elif scoreType == "no_worse_L_minus_1_polsby_popper":
+        depends = dependencies("polsby_popper", POP, AREA)
+
     elif scoreType == "no_vanishing_districts":
         depends = dependencies("population", POP, AREA)
         depends['cut_edges'] = updates.cut_edges
@@ -200,7 +206,7 @@ def escores_edata(config, evalScores, evalScoresData):
 
         chainfunc = functools.partial(handle_scores_separately, handlers=eval_scores)
 
-    return eval_scores, chainfunc, funcs, output_vis_type, output_file_name
+    return eval_scores, chainfunc, eval_list, output_vis_type, output_file_name
 
 
 def read_basic_config(configFileName):

--- a/rundmcmc/parse_config.py
+++ b/rundmcmc/parse_config.py
@@ -186,6 +186,7 @@ def escores_edata(config, evalScores, evalScoresData):
     output_file_name = None
     output_vis_type = lambda x, y, z: 0
     chainfunc = lambda x: 0
+    eval_list = []
 
     if config.has_section('EVALUATION_SCORES'):
         eval_list = config['EVALUATION_SCORES'].values()

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -62,6 +62,7 @@ class WithinPercentRangeOfBounds:
         else:
             return self.lbound <= self.func(partition) <= self.ubound
 
+
 def L1_reciprocal_discrete_polsby_popper(partition):
     return sum(1 / value for value in partition['discrete_polsby_popper'].values())
 

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -50,7 +50,7 @@ no_worse_L1_reciprocal_polsby_popper = SelfConfiguringUpperBound(L1_reciprocal_p
 class WithinPercentRangeOfBounds:
     def __init__(self, func, percent):
         self.func = func
-        self.percent = float(percent)
+        self.percent = float(percent) / 100.
         self.lbound = None
         self.ubound = None
 

--- a/rundmcmc/validity.py
+++ b/rundmcmc/validity.py
@@ -47,6 +47,21 @@ no_worse_L_minus_1_polsby_popper = SelfConfiguringLowerBound(L_minus_1_polsby_po
 no_worse_L1_reciprocal_polsby_popper = SelfConfiguringUpperBound(L1_reciprocal_polsby_popper)
 
 
+class WithinPercentRangeOfBounds:
+    def __init__(self, func, percent):
+        self.func = func
+        self.percent = float(percent)
+        self.lbound = None
+        self.ubound = None
+
+    def __call__(self, partition):
+        if not (self.lbound and self.ubound):
+            self.lbound = self.func(partition) * (1.0 - self.percent)
+            self.ubound = self.func(partition) * (1.0 + self.percent)
+            return True
+        else:
+            return self.lbound <= self.func(partition) <= self.ubound
+
 def L1_reciprocal_discrete_polsby_popper(partition):
     return sum(1 / value for value in partition['discrete_polsby_popper'].values())
 
@@ -310,6 +325,13 @@ def districts_within_tolerance(partition, attribute_name="population", percentag
 
     within_tolerance = max_difference <= percentage * min(values)
     return within_tolerance
+
+
+# NOTE: this returns the maximum imbalance of popuation
+def population_balance(partition, attribute_name="population"):
+    values = partition[attribute_name].values()
+    max_difference = max(values) - min(values)
+    return max_difference / min(values)
 
 
 def refuse_new_splits(partition_county_field):


### PR DESCRIPTION
new class in validity.py allows one to specify a validator and allow a percentage of the 
original plan's range tolerance. TODO: insure that this spits out rage if someone tries to use it with boolean-valued validity functions