### PR TITLE
Add validator tracking to template

### DIFF
--- a/rundmcmc/parse_log.py
+++ b/rundmcmc/parse_log.py
@@ -1,0 +1,27 @@
+from collections import Counter
+import matplotlib.pyplot as plt
+import numpy as np
+import re
+
+log_name = "template.log"
+
+regex = re.compile("constraint failed: (.*)")
+
+fails = []
+with open(log_name) as f:
+    for line in f:
+        match = regex.search(line.strip())
+
+        if match:
+            fails.append(match.group(1))
+
+counter = Counter(fails)
+
+labels, values = zip(*counter.items())
+indexes = np.arange(len(labels))
+width = 1
+
+plt.style.use("ggplot")
+plt.bar(indexes, values, width)
+plt.xticks(indexes, labels)
+plt.show()

--- a/rundmcmc/template_main_multi.py
+++ b/rundmcmc/template_main_multi.py
@@ -44,7 +44,7 @@ from rundmcmc.output import p_value_report
 
 from vis_output import (hist_of_table_scores, trace_of_table_scores)
 
-logging.basicConfig(filename="template.log", format="{name},{lineno},{msg}", style="{", filemode="w", level=logging.DEBUG)
+logging.basicConfig(filename="template.log", format="{name}:{lineno} {msg}", style="{", filemode="w", level=logging.DEBUG)
 
 # Set random seed.
 random.seed(1835)

--- a/rundmcmc/template_main_multi.py
+++ b/rundmcmc/template_main_multi.py
@@ -7,6 +7,7 @@ import functools
 import os
 import datetime
 import random
+import logging
 
 # Imports for RunDMCMC components
 # You can look at the list of available functions in each
@@ -42,6 +43,8 @@ from rundmcmc.run import pipe_to_table
 from rundmcmc.output import p_value_report
 
 from vis_output import (hist_of_table_scores, trace_of_table_scores)
+
+logging.basicConfig(filename="template.log", format="{name},{lineno},{msg}", style="{", filemode="w", level=logging.DEBUG)
 
 # Set random seed.
 random.seed(1835)

--- a/rundmcmc/template_main_multi.py
+++ b/rundmcmc/template_main_multi.py
@@ -44,7 +44,8 @@ from rundmcmc.output import p_value_report
 
 from vis_output import (hist_of_table_scores, trace_of_table_scores)
 
-logging.basicConfig(filename="template.log", format="{name}:{lineno} {msg}", style="{", filemode="w", level=logging.DEBUG)
+logging.basicConfig(filename="template.log", format="{name}:{lineno} {msg}",
+                    style="{", filemode="w", level=logging.DEBUG)
 
 # Set random seed.
 random.seed(1835)


### PR DESCRIPTION
This adds a simple logging feature to `template_main_multi.py` that will track how often certain validators are rejecting proposals. Also, `Bound`, `UpperBound`, and `LowerBound` now have meaningful `__name__` attributes.