### PR TITLE
Allow column names that start with numbers

### DIFF
--- a/examples/parts_graph.py
+++ b/examples/parts_graph.py
@@ -1,0 +1,27 @@
+from collections import defaultdict
+import networkx
+
+from rundmcmc.defaults import PA_partition
+from rundmcmc.defaults import BasicChain
+
+
+def parts_adjacency_matrix(partition):
+    parts_graph = networkx.Graph()
+    for part in partition.parts:
+        parts_graph.add_node(part)
+    for edge in partition['cut_edges']:
+        source, destination = (partition.assignment[node] for node in edge)
+        parts_graph.add_edge(source, destination)
+    nodelist = sorted(list(partition.parts.keys()))
+    return networkx.to_numpy_matrix(parts_graph, nodelist=nodelist)
+
+
+def main():
+    partition = PA_partition()
+    chain = BasicChain(partition, 100)
+    for state in chain:
+        print(parts_adjacency_matrix(state))
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/parts_graph.py
+++ b/examples/parts_graph.py
@@ -1,8 +1,6 @@
-from collections import defaultdict
 import networkx
 
-from rundmcmc.defaults import PA_partition
-from rundmcmc.defaults import BasicChain
+from rundmcmc.defaults import BasicChain, PA_partition
 
 
 def parts_adjacency_matrix(partition):

--- a/rundmcmc/make_graph.py
+++ b/rundmcmc/make_graph.py
@@ -98,7 +98,7 @@ def construct_graph_from_df(df, id_column=None, cols_to_add=None):
     add_boundary_perimeters(graph)
 
     if cols_to_add is not None:
-        add_data_to_graph(data, graph, cols_to_add)
+        add_data_to_graph(df, graph, cols_to_add)
 
     return graph
 

--- a/rundmcmc/make_graph.py
+++ b/rundmcmc/make_graph.py
@@ -95,7 +95,7 @@ def construct_graph_from_df(df, id_column=None, cols_to_add=None):
 
     graph = networkx.from_dict_of_dicts(vtds)
 
-    add_boundary_perimeters(graph)
+    add_boundary_perimeters(graph, neighbors, df)
 
     if cols_to_add is not None:
         add_data_to_graph(df, graph, cols_to_add)

--- a/rundmcmc/make_graph.py
+++ b/rundmcmc/make_graph.py
@@ -98,7 +98,7 @@ def construct_graph_from_df(df, id_column=None, cols_to_add=None):
     add_boundary_perimeters(graph)
 
     if cols_to_add is not None:
-        add_data_to_graph(data, graph, cols_to_add, geoid_col)
+        add_data_to_graph(data, graph, cols_to_add)
 
     return graph
 
@@ -115,7 +115,7 @@ def construct_graph_from_json(json_file):
     return json_graph.adjacency_graph(data)
 
 
-def construct_graph_from_file(filename, geoid_col=None, cols_to_add=None):
+def construct_graph_from_file(filename, id_column=None, cols_to_add=None):
     """
     Constuct the initial graph from any file that fiona can read.
 
@@ -123,20 +123,20 @@ def construct_graph_from_file(filename, geoid_col=None, cols_to_add=None):
     that the fiona library supports.
 
     :filename: file to read
-    :geoid_col: unique identifier column for the data units; used as node ids in the graph
+    :id_column: unique identifier column for the data units; used as node ids in the graph
     :cols_to_add: list of column names from file of data to be added to each node
     :returns: networkx graph
     """
     df = gp.read_file(filename)
-    return construct_graph_from_df(df, geoid_col, cols_to_add)
+    return construct_graph_from_df(df, id_column, cols_to_add)
 
 
-def construct_graph(data_source, geoid_col=None, data_cols=None, data_source_type="fiona"):
+def construct_graph(data_source, id_column=None, data_cols=None, data_source_type="fiona"):
     """
     Construct initial graph from given data source.
 
     :data_source: data from which to create graph ("fiona", "geo_data_frame", or "json".)
-    :geoid_col: name of unique identifier for basic data units
+    :id_column: name of unique identifier for basic data units
     :data_cols: any extra data contained in data_source to be added to nodes of graph
     :data_source_type: string specifying the type of data_source;
                        can be one of "fiona", "json", or "geo_data_frame".
@@ -154,13 +154,13 @@ def construct_graph(data_source, geoid_col=None, data_cols=None, data_source_typ
 
     """
     if data_source_type == "fiona":
-        return construct_graph_from_file(data_source, geoid_col, data_cols)
+        return construct_graph_from_file(data_source, id_column, data_cols)
 
     elif data_source_type == "json":
         return construct_graph_from_json(data_source)
 
     elif data_source_type == "geo_data_frame":
-        return construct_graph_from_df(data_source, geoid_col, data_cols)
+        return construct_graph_from_df(data_source, id_column, data_cols)
 
 
 def get_assignment_dict(df, key_col, val_col):

--- a/rundmcmc/make_graph.py
+++ b/rundmcmc/make_graph.py
@@ -33,61 +33,22 @@ def get_list_of_data(filepath, col_name, geoid=None):
     return data
 
 
-def add_data_to_graph(df, graph, col_names, id_col=None):
-    """Add columns of a dataframe to a graph based on ids.
+def add_data_to_graph(df, graph, col_names):
+    """Add columns of a dataframe to a graph based on ids. We assume
+    that the dataframe df is indexed by the node ids.
 
     :df: Dataframe containing given column.
     :graph: NetworkX object containing appropriately labeled nodes.
     :col_names: List of dataframe column names to add.
-    :id_col: The column name to pull graph ids from. The row from this id will
-             be assigned to the corresponding node in the graph. If `None`,
-             then the data is assigned to consecutive integer labels 0, 1, ...,
-             len(graph) - 1.
-
     """
-    if id_col:
-        for row in df.itertuples():
-            node = getattr(row, id_col)
-            for name in col_names:
-                data = getattr(row, name)
-                graph.nodes[node][name] = data
-    else:
-        for i, row in enumerate(df.itertuples()):
-            for name in col_names:
-                data = getattr(row, name)
-                graph.nodes[i][name] = data
+    column_dictionaries = df[col_names].to_dict('index')
+    networkx.set_node_attributes(graph, column_dictionaries)
 
 
-def construct_graph_from_df(df, geoid_col=None, cols_to_add=None):
-    """Construct initial graph from information about neighboring VTDs.
-
-    :df: Geopandas dataframe.
-    :returns: NetworkX Graph.
-
-    """
-    if geoid_col is not None:
-        df = df.set_index(geoid_col)
-
-    # Generate rook neighbor lists from dataframe.
-    neighbors = ps.weights.Rook.from_dataframe(
-        df, geom_col="geometry").neighbors
-
-    vtds = {}
-
-    for shape in neighbors:
-
-        vtds[shape] = {}
-
-        for neighbor in neighbors[shape]:
-            shared_perim = df.loc[shape, "geometry"].intersection(
-                df.loc[neighbor, "geometry"]).length
-            vtds[shape][neighbor] = {'shared_perim': shared_perim}
-
-    graph = networkx.from_dict_of_dicts(vtds)
-    vtd = df['geometry']
-
+def add_boundary_perimeters(graph, neighbors, df):
+    all_units = df['geometry']
     # creates one shape of the entire state to compare outer boundaries against
-    inter = gp.GeoSeries(cascaded_union(vtd).boundary)
+    inter = gp.GeoSeries(cascaded_union(all_units).boundary)
 
     # finds if it intersects on outside and sets
     # a 'boundary_node' attribute to true if it does
@@ -99,12 +60,46 @@ def construct_graph_from_df(df, geoid_col=None, cols_to_add=None):
         if inter.intersects(df.loc[node, "geometry"]).bool():
             graph.node[node]['boundary_perim'] = float(
                 inter.intersection(df.loc[node, "geometry"]).length)
+    return graph
+
+
+def neighbors_with_shared_perimeters(neighbors, df):
+    vtds = {}
+
+    for shape in neighbors:
+        vtds[shape] = {}
+
+        for neighbor in neighbors[shape]:
+            shared_perim = df.loc[shape, "geometry"].intersection(
+                df.loc[neighbor, "geometry"]).length
+            vtds[shape][neighbor] = {'shared_perim': shared_perim}
+
+    return vtds
+
+
+def construct_graph_from_df(df, id_column=None, cols_to_add=None):
+    """Construct initial graph from information about neighboring VTDs.
+
+    :df: Geopandas dataframe.
+    :returns: NetworkX Graph.
+
+    """
+    if id_column is not None:
+        df = df.set_index(id_column)
+
+    # Generate rook neighbor lists from dataframe.
+    neighbors = ps.weights.Rook.from_dataframe(
+        df, geom_col="geometry").neighbors
+
+    vtds = neighbors_with_shared_perimeters(neighbors, df)
+
+    graph = networkx.from_dict_of_dicts(vtds)
+
+    add_boundary_perimeters(graph)
 
     if cols_to_add is not None:
-        data = pd.DataFrame({x: df[x] for x in cols_to_add})
-        if geoid_col is not None:
-            data[geoid_col] = df.index
         add_data_to_graph(data, graph, cols_to_add, geoid_col)
+
     return graph
 
 

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -1,0 +1,16 @@
+import networkx
+import pandas
+
+from rundmcmc.make_graph import add_data_to_graph
+
+
+def test_add_data_to_graph_can_handle_column_names_that_start_with_numbers():
+    graph = networkx.Graph([('01', '02'), ('02', '03'), ('03', '01')])
+    df = pandas.DataFrame({'16SenDVote': [20, 30, 50], 'node': ['01', '02', '03']})
+    df = df.set_index('node')
+
+    add_data_to_graph(df, graph, ['16SenDVote'])
+
+    assert graph.nodes['01']['16SenDVote'] == 20
+    assert graph.nodes['02']['16SenDVote'] == 30
+    assert graph.nodes['03']['16SenDVote'] == 50


### PR DESCRIPTION
- Avoid itertuples to allow for column names that start with numbers. This closes #177 . Also added a test to prove that this works.
- Added an example of getting the parts-level adjacency matrix, for the Alaska team.
- Moved some parts of `construct_graph_from_df` into their own functions, for clarity.