### PR TITLE
Building out template functionality and grid example

### DIFF
--- a/rundmcmc/grid.py
+++ b/rundmcmc/grid.py
@@ -111,14 +111,14 @@ def color_quadrants(node, thresholds):
 def grid_size(parition):
     ''' This is a hardcoded population function
     for the grid class'''
-    
-    L=parition.as_list_of_lists()
-    permit=[3,4,5]
 
-    sizes=[0,0,0,0]
-    
+    L = parition.as_list_of_lists()
+    permit = [3, 4, 5]
+
+    sizes = [0, 0, 0, 0]
+
     for i in range(len(L)):
         for j in range(len(L[0])):
-            sizes[L[i][j]]+=1
-            
+            sizes[L[i][j]] += 1
+
     return all(x in permit for x in sizes)

--- a/rundmcmc/grid.py
+++ b/rundmcmc/grid.py
@@ -106,3 +106,19 @@ def color_quadrants(node, thresholds):
     x_color = 0 if x < thresholds[0] else 1
     y_color = 0 if y < thresholds[1] else 2
     return x_color + y_color
+
+
+def grid_size(parition):
+    ''' This is a hardcoded population function
+    for the grid class'''
+    
+    L=parition.as_list_of_lists()
+    permit=[3,4,5]
+
+    sizes=[0,0,0,0]
+    
+    for i in range(len(L)):
+        for j in range(len(L[0])):
+            sizes[L[i][j]]+=1
+            
+    return all(x in permit for x in sizes)

--- a/rundmcmc/run.py
+++ b/rundmcmc/run.py
@@ -51,17 +51,18 @@ def handle_chain(chain, handlers):
         yield {key: handler(state) for key, handler in handlers.items()}
 
 
-def pipe_to_table(chain, handlers, display=True, display_frequency=100,
-                  bin_frequency=1):
+def pipe_to_table(chain, handlers, display=True, number_to_display=10,
+                  number_to_bin=100):
     table = ChainOutputTable()
-    display_interval = math.floor(len(chain) / display_frequency)
+    display_interval = math.floor(len(chain) / number_to_display)
+    bin_interval = math.floor(len(chain) / number_to_bin)
     counter = 0
     for row in handle_chain(chain, handlers):
         if counter % display_interval == 0:
             if display:
                 print(f"Step {counter}")
                 print(row)
-        if counter % bin_frequency == 0:
+        if counter % bin_interval == 0:
             table.append(row)
         counter += 1
     return table

--- a/rundmcmc/scores.py
+++ b/rundmcmc/scores.py
@@ -129,3 +129,27 @@ def how_many_seats(col1, col2):
     def function(partition):
         return sum(partition[col1][part] > partition[col2][part] for part in partition.parts)
     return function
+
+def how_many_seats_value(partition, col1, col2):
+    return sum(partition[col1][part] > partition[col2][part] for part in partition.parts)
+
+def population_range(partition):
+    return (max(partition["population"].values())-min(partition["population"].values()))
+
+def number_cut_edges(partition):
+    return len(partition["cut_edges"])
+
+def number_boundary_nodes(partition):
+    return len(partition["boundary_nodes"])
+
+def number_boundary_components(partition):
+    return len(partition["cut_edges_by_part"].values())
+
+
+
+def mean_pop(partition):
+    number_of_districts = len(initial_partition['population'].keys())
+    total_population = sum(initial_partition['population'].values())
+    ideal_population = total_population / number_of_districts
+
+    return ideal_population

--- a/rundmcmc/scores.py
+++ b/rundmcmc/scores.py
@@ -130,26 +130,30 @@ def how_many_seats(col1, col2):
         return sum(partition[col1][part] > partition[col2][part] for part in partition.parts)
     return function
 
+
 def how_many_seats_value(partition, col1, col2):
     return sum(partition[col1][part] > partition[col2][part] for part in partition.parts)
 
+
 def population_range(partition):
-    return (max(partition["population"].values())-min(partition["population"].values()))
+    return (max(partition["population"].values()) - min(partition["population"].values()))
+
 
 def number_cut_edges(partition):
     return len(partition["cut_edges"])
 
+
 def number_boundary_nodes(partition):
     return len(partition["boundary_nodes"])
+
 
 def number_boundary_components(partition):
     return len(partition["cut_edges_by_part"].values())
 
 
-
 def mean_pop(partition):
-    number_of_districts = len(initial_partition['population'].keys())
-    total_population = sum(initial_partition['population'].values())
-    ideal_population = total_population / number_of_districts
+    number_of_districts = len(partition['population'].keys())
+    total_population = sum(partition['population'].values())
+    mean_population = total_population / number_of_districts
 
-    return ideal_population
+    return mean_population

--- a/rundmcmc/template_main_grid.py
+++ b/rundmcmc/template_main_grid.py
@@ -38,7 +38,7 @@ os.makedirs(os.path.dirname(newdir + "init.txt"), exist_ok=True)
 with open(newdir + "init.txt", "w") as f:
     f.write("Created Folder")
 
-i=1
+i = 1
 for partition in chain:
     plt.matshow(partition.as_list_of_lists())
     plt.savefig(newdir + "g3_%04d.png" % i)

--- a/rundmcmc/template_main_grid.py
+++ b/rundmcmc/template_main_grid.py
@@ -4,8 +4,6 @@ import matplotlib.pyplot as plt
 
 from rundmcmc.grid import Grid, grid_size
 
-from rundmcmc.run import pipe_to_table
-
 from rundmcmc.validity import (fast_connected, Validator, no_vanishing_districts,
                                within_percent_of_ideal_population)
 
@@ -16,9 +14,9 @@ from rundmcmc.accept import always_accept
 from rundmcmc.chain import MarkovChain
 
 
-# Makes a simple grid and runs the MCMC. Mostly for testing proposals. 
+# Makes a simple grid and runs the MCMC. Mostly for testing proposals
 
-grid = Grid((20,20))  # was (4,4)
+grid = Grid((20, 20))  # was (4,4)
 
 pop_limit = .3
 population_constraint = within_percent_of_ideal_population(grid, pop_limit)
@@ -26,9 +24,9 @@ population_constraint = within_percent_of_ideal_population(grid, pop_limit)
 grid_validator2 = Validator([fast_connected, no_vanishing_districts,
                              population_constraint])
 
-grid_validator = Validator([fast_connected, no_vanishing_districts,grid_size])
+grid_validator = Validator([fast_connected, no_vanishing_districts, grid_size])
 
-dumb_validator = Validator([fast_connected,no_vanishing_districts])
+dumb_validator = Validator([fast_connected, no_vanishing_districts])
 
 
 chain = MarkovChain(reversible_chunk_flip, grid_validator2, always_accept,
@@ -43,7 +41,7 @@ with open(newdir + "init.txt", "w") as f:
 i=1
 for partition in chain:
     plt.matshow(partition.as_list_of_lists())
-    plt.savefig(newdir + "g3_%04d.png"%i)
+    plt.savefig(newdir + "g3_%04d.png" % i)
     plt.close()
     i += 1
 

--- a/rundmcmc/template_main_grid.py
+++ b/rundmcmc/template_main_grid.py
@@ -1,0 +1,52 @@
+import os
+
+import matplotlib.pyplot as plt
+
+from rundmcmc.grid import Grid, grid_size
+
+from rundmcmc.run import pipe_to_table
+
+from rundmcmc.validity import (fast_connected, Validator, no_vanishing_districts,
+                               within_percent_of_ideal_population)
+
+from rundmcmc.proposals import reversible_chunk_flip
+
+from rundmcmc.accept import always_accept
+
+from rundmcmc.chain import MarkovChain
+
+
+# Makes a simple grid and runs the MCMC. Mostly for testing proposals. 
+
+grid = Grid((20,20))  # was (4,4)
+
+pop_limit = .3
+population_constraint = within_percent_of_ideal_population(grid, pop_limit)
+
+grid_validator2 = Validator([fast_connected, no_vanishing_districts,
+                             population_constraint])
+
+grid_validator = Validator([fast_connected, no_vanishing_districts,grid_size])
+
+dumb_validator = Validator([fast_connected,no_vanishing_districts])
+
+
+chain = MarkovChain(reversible_chunk_flip, grid_validator2, always_accept,
+                    grid, total_steps=100)
+
+# Outputs .pngs for animating
+newdir = "./Outputs/Grid_Plots/"
+os.makedirs(os.path.dirname(newdir + "init.txt"), exist_ok=True)
+with open(newdir + "init.txt", "w") as f:
+    f.write("Created Folder")
+
+i=1
+for partition in chain:
+    plt.matshow(partition.as_list_of_lists())
+    plt.savefig(newdir + "g3_%04d.png"%i)
+    plt.close()
+    i += 1
+
+# To animate:
+# ffmpeg -framerate 5 -i g3_%04d.png -c:v libx264
+# -profile:v high -crf 20 -pix_fmt yuv420p grid3.mp4

--- a/rundmcmc/template_main_multi.py
+++ b/rundmcmc/template_main_multi.py
@@ -93,7 +93,7 @@ vote_path = "./testData/wes_with_districtings.shp"
 
 # This inputs a shapefile with columns you want to add
 df = gp.read_file(vote_path)
-
+df = df.set_index(unique_label)
 
 # This is the number of elections you want to analyze
 num_elections = 2

--- a/rundmcmc/template_main_multi.py
+++ b/rundmcmc/template_main_multi.py
@@ -38,8 +38,8 @@ from rundmcmc.validity import (L1_reciprocal_polsby_popper,
 
 from rundmcmc.scores import (efficiency_gap, mean_median,
                              mean_thirdian, how_many_seats_value,
-                             population_range, number_boundary_components,
-                             number_cut_edges, number_boundary_nodes)
+                             population_range,
+                             number_cut_edges)
 
 from rundmcmc.run import pipe_to_table
 
@@ -105,7 +105,8 @@ election_columns = [['T16PRESD', 'T16PRESR'], ['T16SEND', 'T16SENR']]
 
 
 # This adds the data to the graph
-add_data_to_graph(df, graph, [cols for pair in election_columns for cols in pair])#, id_col=unique_label)
+add_data_to_graph(df, graph, [cols for pair in election_columns for cols in pair])
+# , id_col=unique_label)
 
 
 # Desired proposal method

--- a/rundmcmc/template_main_multi.py
+++ b/rundmcmc/template_main_multi.py
@@ -30,13 +30,16 @@ from rundmcmc.updaters import (Tally, boundary_nodes, cut_edges,
                                interior_boundaries)
 
 from rundmcmc.validity import (L1_reciprocal_polsby_popper,
-                               UpperBound,
+                               L_minus_1_polsby_popper,
+                               UpperBound, LowerBound,
                                Validator, no_vanishing_districts,
                                refuse_new_splits, single_flip_contiguous,
                                within_percent_of_ideal_population)
 
 from rundmcmc.scores import (efficiency_gap, mean_median,
-                             mean_thirdian)
+                             mean_thirdian, how_many_seats_value,
+                             population_range, number_boundary_components,
+                             number_cut_edges, number_boundary_nodes)
 
 from rundmcmc.run import pipe_to_table
 
@@ -52,7 +55,7 @@ random.seed(1835)
 
 # Make a folder for the output
 current = datetime.datetime.now()
-newdir = "./PAoutputs-" + str(current)[:10] + "-" + str(current)[11:13]\
+newdir = "./Outputs/PAoutputs-" + str(current)[:10] + "-" + str(current)[11:13]\
          + "-" + str(current)[14:16] + "-" + str(current)[17:19] + "/"
 
 os.makedirs(os.path.dirname(newdir + "init.txt"), exist_ok=True)
@@ -70,14 +73,14 @@ unique_label = "wes_id"
 # Names of graph columns go here
 pop_col = "population"
 area_col = "area"
-district_col = "rounded11"
+district_col = "Remedial"
 
 
 # This builds a graph
 graph = construct_graph(graph_path, data_source_type="json")
 
 # Write graph to file
-with open(newdir + state_name + 'graph_with_data.json', 'w') as outfile1:
+with open(newdir + state_name + '_graph_with_data.json', 'w') as outfile1:
     outfile1.write(json.dumps(json_graph.adjacency_data(graph)))
 
 # Put district on graph
@@ -102,8 +105,7 @@ election_columns = [['T16PRESD', 'T16PRESR'], ['T16SEND', 'T16SENR']]
 
 
 # This adds the data to the graph
-add_data_to_graph(df, graph, [cols for pair in election_columns for cols in pair],
-                  id_col=unique_label)
+add_data_to_graph(df, graph, [cols for pair in election_columns for cols in pair])#, id_col=unique_label)
 
 
 # Desired proposal method
@@ -115,7 +117,7 @@ acceptance_method = always_accept
 
 
 # Number of steps to run
-steps = 100
+steps = 1000
 
 print("loaded data")
 
@@ -147,18 +149,21 @@ initial_partition = Partition(graph, assignment, updaters)
 pop_limit = .01
 population_constraint = within_percent_of_ideal_population(initial_partition, pop_limit)
 
-compactness_limit = 1.01 * L1_reciprocal_polsby_popper(initial_partition)
-compactness_constraint = UpperBound(L1_reciprocal_polsby_popper, compactness_limit)
+compactness_limit_L1 = 1.01 * L1_reciprocal_polsby_popper(initial_partition)
+compactness_constraint_L1 = UpperBound(L1_reciprocal_polsby_popper, compactness_limit_L1)
+
+compactness_limit_Lm1 = .99 * L_minus_1_polsby_popper(initial_partition)
+compactness_constraint_Lm1 = LowerBound(L_minus_1_polsby_popper, compactness_limit_Lm1)
 
 validator = Validator([refuse_new_splits, no_vanishing_districts,
                        single_flip_contiguous, population_constraint,
-                       compactness_constraint])
+                       compactness_constraint_Lm1])
 
 # Names of validators for output
 # Necessary since bounds don't have __name__'s
 list_of_validators = [refuse_new_splits, no_vanishing_districts,
                       single_flip_contiguous, within_percent_of_ideal_population,
-                      L1_reciprocal_polsby_popper]
+                      L_minus_1_polsby_popper]
 
 
 # Add cyclic updaters :(
@@ -178,7 +183,14 @@ print("ran chain")
 # Post processing commands go below
 # Adds election Scores
 
-scores = {}
+scores = {
+    'L1 Reciprocal Polsby-Popper': L1_reciprocal_polsby_popper,
+    'L -1 Polsby-Popper': L_minus_1_polsby_popper,
+    'Population Range': population_range,
+    'Conflicted Edges': number_cut_edges,
+    }
+
+chain_stats = scores.copy()
 
 scores_for_plots = []
 
@@ -194,8 +206,11 @@ for i in range(num_elections):
         election_names[i]: functools.partial(efficiency_gap,
                                              col1=election_columns[i][0],
                                              col2=election_columns[i][1]),
-        'L1 Reciprocal Polsby-Popper' + "\n" +
-        election_names[i]: L1_reciprocal_polsby_popper}
+        'Number of Democratic Seats' + "\n" +
+        election_names[i]: functools.partial(how_many_seats_value,
+                                             col1=election_columns[i][0],
+                                             col2=election_columns[i][1])
+        }
 
     scores_for_plots.append(vscores)
 
@@ -204,19 +219,19 @@ for i in range(num_elections):
 # Compute the values of the intial state and the chain
 initial_scores = {key: score(initial_partition) for key, score in scores.items()}
 
-table = pipe_to_table(chain, scores, display=True, display_frequency=10,
-                      bin_frequency=1)
+table = pipe_to_table(chain, scores, display=True, number_to_display=10,
+                      number_to_bin=steps)
 
 
 # P-value reports
 pv_dict = {key: p_value_report(key, table[key], initial_scores[key]) for key in scores}
-print(pv_dict)
+# print(pv_dict)
 with open(newdir + 'pvals_report_multi.json', 'w') as fp:
     json.dump(pv_dict, fp)
 
 print("computed p-values")
 
-
+"""
 # Write flips to file
 
 allAssignments = {0: chain.state.assignment}
@@ -228,7 +243,7 @@ with open(newdir + "chain_flips_multi.json", "w") as fp:
     json.dump(allAssignments, fp)
 
 print("wrote flips")
-
+"""
 
 # Histogram and trace plotting paths
 hist_path = newdir + "chain_histogram_multi_"
@@ -247,6 +262,16 @@ for i in range(num_elections):
                           outputFile=trace_path + election_names[i] + ".png",
                           name=state_name + "\n" + election_names[i])
 
+
+# Plot for chain stats
+
+hist_of_table_scores(table, scores=chain_stats,
+                     outputFile=hist_path + "stats.png",
+                     num_bins=50, name=state_name + "\n" + district_col)
+
+trace_of_table_scores(table, scores=chain_stats,
+                      outputFile=trace_path + "stats.png",
+                      name=state_name + "\n" + district_col)
 
 print("plotted histograms")
 print("plotted traces")
@@ -280,7 +305,7 @@ with open(newdir + "parameters.txt", "w") as f:
     f.write("Acceptance Method: " + acceptance_method.__name__)
     f.write("\n")
     f.write("\n")
-    f.write("Validators: ")
+    f.write("Binary Constraints: ")
     f.write("\n")
     for v in list_of_validators:
         f.write(v.__name__ + "\n")


### PR DESCRIPTION
Modified template to report chain stats separately from partisan metrics. This requires adding a couple of silly functions to scores in order to call with the proper syntax. 

Moved output writing to a new Outputs folder. 

 Updated the terminology for number_to_display and number_to_bin. 

Also included a grid example for testing proposals and acceptance functions. 