### PR TITLE
Accept id_column argument in add_data_to_graph

### DIFF
--- a/rundmcmc/make_graph.py
+++ b/rundmcmc/make_graph.py
@@ -35,7 +35,7 @@ def get_list_of_data(filepath, col_name, geoid=None):
     return data
 
 
-def add_data_to_graph(df, graph, col_names):
+def add_data_to_graph(df, graph, col_names, id_column=None):
     """Add columns of a dataframe to a graph using the the index as node ids.
 
     :df: Dataframe containing given columns.
@@ -44,7 +44,12 @@ def add_data_to_graph(df, graph, col_names):
     :returns: Nothing.
 
     """
-    column_dictionaries = df[col_names].to_dict('index')
+    if id_column:
+        indexed_df = df.set_index(id_column)
+    else:
+        indexed_df = df
+
+    column_dictionaries = indexed_df[col_names].to_dict('index')
     networkx.set_node_attributes(graph, column_dictionaries)
 
 

--- a/rundmcmc/scores.py
+++ b/rundmcmc/scores.py
@@ -27,7 +27,7 @@ def mean_median(partition, proportion_column_name):
     if proportion_column_name[-1] != "%":
         proportion_column_name = proportion_column_name + "%"
     data = list(partition[proportion_column_name].values())
-    return numpy.mean(data) - numpy.median(data)
+    return numpy.median(data) - numpy.mean(data)
 
 
 def mean_thirdian(partition, proportion_column_name):
@@ -35,7 +35,7 @@ def mean_thirdian(partition, proportion_column_name):
         proportion_column_name = proportion_column_name + "%"
 
     data = list(partition[proportion_column_name].values())
-    return numpy.mean(data) - numpy.percentile(data, 33)
+    return numpy.percentile(data, 33) - numpy.mean(data)
 
 
 def normalized_efficiency_gap(partition, proportion_column_name):

--- a/rundmcmc/scores.py
+++ b/rundmcmc/scores.py
@@ -27,7 +27,7 @@ def mean_median(partition, proportion_column_name):
     if proportion_column_name[-1] != "%":
         proportion_column_name = proportion_column_name + "%"
     data = list(partition[proportion_column_name].values())
-    return numpy.median(data) - numpy.mean(data)
+    return numpy.mean(data) - numpy.median(data)
 
 
 def mean_thirdian(partition, proportion_column_name):
@@ -35,7 +35,7 @@ def mean_thirdian(partition, proportion_column_name):
         proportion_column_name = proportion_column_name + "%"
 
     data = list(partition[proportion_column_name].values())
-    return numpy.percentile(data, 33) - numpy.mean(data)
+    return numpy.mean(data) - numpy.percentile(data, 33)
 
 
 def normalized_efficiency_gap(partition, proportion_column_name):
@@ -129,31 +129,3 @@ def how_many_seats(col1, col2):
     def function(partition):
         return sum(partition[col1][part] > partition[col2][part] for part in partition.parts)
     return function
-
-
-def how_many_seats_value(partition, col1, col2):
-    return sum(partition[col1][part] > partition[col2][part] for part in partition.parts)
-
-
-def population_range(partition):
-    return (max(partition["population"].values()) - min(partition["population"].values()))
-
-
-def number_cut_edges(partition):
-    return len(partition["cut_edges"])
-
-
-def number_boundary_nodes(partition):
-    return len(partition["boundary_nodes"])
-
-
-def number_boundary_components(partition):
-    return len(partition["cut_edges_by_part"].values())
-
-
-def mean_pop(partition):
-    number_of_districts = len(partition['population'].keys())
-    total_population = sum(partition['population'].values())
-    mean_population = total_population / number_of_districts
-
-    return mean_population

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -14,3 +14,14 @@ def test_add_data_to_graph_can_handle_column_names_that_start_with_numbers():
     assert graph.nodes['01']['16SenDVote'] == 20
     assert graph.nodes['02']['16SenDVote'] == 30
     assert graph.nodes['03']['16SenDVote'] == 50
+
+
+def test_add_data_to_graph_can_handle_unset_index_when_id_col_is_passed():
+    graph = networkx.Graph([('01', '02'), ('02', '03'), ('03', '01')])
+    df = pandas.DataFrame({'16SenDVote': [20, 30, 50], 'node': ['01', '02', '03']})
+
+    add_data_to_graph(df, graph, ['16SenDVote'], id_column='node')
+
+    assert graph.nodes['01']['16SenDVote'] == 20
+    assert graph.nodes['02']['16SenDVote'] == 30
+    assert graph.nodes['03']['16SenDVote'] == 50

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,4 +1,4 @@
-from rundmcmc.scores import efficiency_gap, wasted_votes
+from rundmcmc.scores import efficiency_gap, wasted_votes, mean_median
 
 # data from Moon's slides
 data = {
@@ -16,3 +16,29 @@ def test_efficiency_gap():
 def test_wasted_votes():
     result = [wasted_votes(data['A'][i], data['B'][i]) for i in range(1, 6)]
     assert result == [(45, 5), (40, 10), (25, 25), (45, 5), (45, 5)]
+
+
+def test_partisan_scores_point_the_same_way():
+    mock_election = dict()
+    mock_election['a'] = data['A']
+    mock_election['b'] = data['B']
+    mock_election['a%'] = {key: mock_election['a'][key] /
+        (mock_election['a'][key] + mock_election['b'][key]) for key in mock_election['b']}
+
+    eg = efficiency_gap(mock_election, 'a', 'b')
+    mm = mean_median(mock_election, 'a%')
+
+    assert (eg > 0 and mm > 0) or (eg < 0 and mm < 0)
+
+
+def test_partisan_scores_are_positive_if_second_party_has_advantage():
+    mock_election = dict()
+    mock_election['a'] = data['A']
+    mock_election['b'] = data['B']
+    mock_election['a%'] = {key: mock_election['a'][key] /
+        (mock_election['a'][key] + mock_election['b'][key]) for key in mock_election['b']}
+
+    eg = efficiency_gap(mock_election, 'a', 'b')
+    mm = mean_median(mock_election, 'a%')
+
+    assert (eg > 0 and mm > 0)


### PR DESCRIPTION
I added `id_column` back in as an optional argument.

If it is provided then `add_data_to_graph` makes a view of the dataframe indexed by `id_column` and then adds the data. If it is not provided, it assumes that the dataframe is already indexed by node id. This avoids setting the index on the dataframe permanently.

One point of concern is whether people might forget to include the id_column argument, leading to the data not being added, or being added incorrectly. But I think this usage would raise a KeyError when networkx tries to find a node using the wrong ids. One scary scenario where it wouldn't raise a KeyError is if you indexed your nodes by row number, and now are trying to add data from a CSV, also indexed by row number, but where the rows do not match up properly. That situation might be unavoidable though...

If we wanted to be really prudent we could compare the index (or `id_column`) to `graph.nodes` and then raise an exception or log an error if they don't match up. This would take some time, but might be worth it. (It still wouldn't catch the mismatched row numbers scenario though.)

I also:
- Added a test that verifies that the partisan metrics, in the way we are using them, point the same way.
- Added a test to verify that `add_data_to_graph` accepts the `id_column` usage.