### PR TITLE
Fix table.json and add dataframe converter

### DIFF
--- a/rundmcmc/output/output.py
+++ b/rundmcmc/output/output.py
@@ -1,6 +1,7 @@
+from collections import Counter
+import pandas as pd
 import json
 import math
-from collections import Counter
 
 
 def p_value_report(score_name, ensemble_scores, initial_plan_score):
@@ -82,8 +83,15 @@ class ChainOutputTable:
     def append(self, row):
         self.data.append(row)
 
-    def json(self, row):
-        return json.dumps(self.data)
+    def to_json(self, filename=None):
+        if filename is None:
+            return json.dumps(self.data)
+
+        with open(filename, "w") as f:
+            json.dump(self.data, f)
+
+    def to_dataframe(self):
+        return pd.DataFrame(self.data)
 
     def __iter__(self):
         return self

--- a/rundmcmc/templates/template_main_multi.py
+++ b/rundmcmc/templates/template_main_multi.py
@@ -205,11 +205,10 @@ for i in range(num_elections):
         election_names[i]: functools.partial(efficiency_gap,
                                              col1=election_columns[i][0],
                                              col2=election_columns[i][1]),
-        'Number of Democratic Seats' + "\n" +
-        election_names[i]: functools.partial(how_many_seats_value,
-                                             col1=election_columns[i][0],
-                                             col2=election_columns[i][1])
-        }
+        'demseats' + election_names[i]: functools.partial(how_many_seats_value,
+                                                          col1=election_columns[i][0],
+                                                          col2=election_columns[i][1])
+    }
 
     scores_for_plots.append(vscores)
 
@@ -220,6 +219,11 @@ initial_scores = {key: score(initial_partition) for key, score in scores.items()
 
 table = pipe_to_table(chain, scores, display=True, number_to_display=10)
 
+results_df = table.to_dataframe()
+
+for name in election_names:
+    print(results_df["demseats" + name].describe())
+    print()
 
 # P-value reports
 pv_dict = {key: p_value_report(key, table[key], initial_scores[key]) for key in scores}


### PR DESCRIPTION
- `table.json()` no longer takes a row argument (it never used it before anyway).
- ` table.json()` now takes an optional filename argument and writes the JSON out there.
- `table.to_dataframe()` now exists, which should make reporting stats about runs easier; there's an example in `template_main_multi.py` now.