### PR TITLE
Contiguity check speedup

### DIFF
--- a/rundmcmc/validity/validity.py
+++ b/rundmcmc/validity/validity.py
@@ -115,7 +115,9 @@ def single_flip_contiguous(partition):
         assignment, and infinity otherwise.
         """
         if assignment[start_node] != assignment[end_node]:
-            return float("inf")
+            # Fun fact: networkx actually refuses to take edges with None
+            # weight.
+            return None
 
         return 1
 

--- a/rundmcmc/validity/validity.py
+++ b/rundmcmc/validity/validity.py
@@ -106,31 +106,25 @@ def single_flip_contiguous(partition):
         return contiguous(partition)
 
     graph = partition.graph
-    assignment_dict = parent.assignment
-
-    def proposed_assignment(node):
-        """Return the proposed assignment of the given node."""
-        if node in flips:
-            return flips[node]
-
-        return assignment_dict[node]
+    old_dict = parent.assignment
+    assignment = partition.assignment
 
     def partition_edge_weight(start_node, end_node, edge_attrs):
         """
         Compute the district edge weight, which is 1 if the nodes have the same
         assignment, and infinity otherwise.
         """
-        if proposed_assignment(start_node) != proposed_assignment(end_node):
+        if assignment[start_node] != assignment[end_node]:
             return float("inf")
 
         return 1
 
     for changed_node, _ in flips.items():
         old_neighbors = []
-        old_assignment = assignment_dict[changed_node]
+        old_assignment = partition.parent.assignment[changed_node]
 
         for node in graph.neighbors(changed_node):
-            if proposed_assignment(node) == old_assignment:
+            if assignment[node] == old_assignment:
                 old_neighbors.append(node)
 
         if not old_neighbors:

--- a/rundmcmc/validity/validity.py
+++ b/rundmcmc/validity/validity.py
@@ -120,12 +120,10 @@ def single_flip_contiguous(partition):
         return 1
 
     for changed_node, _ in flips.items():
-        old_neighbors = []
         old_assignment = partition.parent.assignment[changed_node]
 
-        for node in graph.neighbors(changed_node):
-            if assignment[node] == old_assignment:
-                old_neighbors.append(node)
+        old_neighbors = [node for node in graph.neighbors(changed_node)
+                         if assignment[node] == old_assignment]
 
         if not old_neighbors:
             # Under our assumptions, if there are no old neighbors, then the

--- a/rundmcmc/validity/validity.py
+++ b/rundmcmc/validity/validity.py
@@ -6,8 +6,6 @@ from heapq import heappush, heappop
 from itertools import count
 
 import networkx as nx
-import networkx.algorithms.shortest_paths.weighted as nx_path
-from networkx import NetworkXNoPath
 
 from rundmcmc.updaters import CountySplit
 from rundmcmc.validity.bounds import (SelfConfiguringLowerBound, SelfConfiguringUpperBound,
@@ -160,7 +158,6 @@ def single_flip_contiguous(partition):
         return contiguous(partition)
 
     graph = partition.graph
-    old_dict = parent.assignment
     assignment = partition.assignment
 
     def partition_edge_avoid(start_node, end_node, edge_attrs):
@@ -312,7 +309,7 @@ def proposed_changes_still_contiguous(partition):
     if partition.parent:
         if partition.flips.keys is not None:
             districts_of_interest = set(partition.flips.values()).union(
-                    set(map(partition.parent.assignment.get, partition.flips)))
+                                        set(map(partition.parent.assignment.get, partition.flips)))
         else:
             districts_of_interest = []
 


### PR DESCRIPTION
`single_flip_contiguity()` is now significantly faster. It uses a modified Dijkstra's algorithm hoisted from NetworkX's implementation that (1) avoids specified nodes, and (2) halts when a specified set of nodes are found.

This is still peanuts in terms of total performance, but it shaves a little off the top.