### PR TITLE
Avoid looping through empty flows, remove unnecessary dict merge

### DIFF
--- a/rundmcmc/updaters/flows.py
+++ b/rundmcmc/updaters/flows.py
@@ -63,15 +63,17 @@ def on_flow(initializer, alias):
 
 def compute_edge_flows(partition):
     edge_flows = collections.defaultdict(create_flow)
+    assignment = partition.assignment
+    old_assignment = partition.parent.assignment
     for node in partition.flips:
         for neighbor in partition.graph.neighbors(node):
             edge = tuple(sorted((node, neighbor)))
 
-            old_source = partition.parent.assignment[node]
-            old_target = partition.parent.assignment[neighbor]
+            old_source = old_assignment[node]
+            old_target = old_assignment[neighbor]
 
-            new_source = partition.assignment[node]
-            new_target = partition.assignment[neighbor]
+            new_source = assignment[node]
+            new_target = assignment[neighbor]
 
             cut = new_source != new_target
             was_cut = old_source != old_target

--- a/rundmcmc/updaters/flows.py
+++ b/rundmcmc/updaters/flows.py
@@ -51,14 +51,12 @@ def on_flow(initializer, alias):
 
             previous = partition.parent[alias]
 
-            new_values = dict()
+            new_values = previous.copy()
 
             for part, flow in partition.flows.items():
                 new_values[part] = function(partition, previous[part], flow['in'], flow['out'])
 
-            result = {**previous, **new_values}
-
-            return result
+            return new_values
         return wrapped
     return decorator
 
@@ -132,8 +130,12 @@ def on_edge_flow(initializer, alias):
                 return initializer(partition)
             edge_flows = partition.edge_flows
             previous = partition.parent[alias]
-            return {part: f(partition, previous[part], new_edges=edge_flows[part]['in'],
-                            old_edges=edge_flows[part]['out'])
-                    for part in partition.parts}
+
+            new_values = previous.copy()
+            for part in partition.edge_flows:
+                new_values[part] = f(partition, previous[part],
+                                     new_edges=edge_flows[part]['in'],
+                                     old_edges=edge_flows[part]['out'])
+            return new_values
         return wrapper
     return decorator


### PR DESCRIPTION
This makes the flow computations in flows.py faster by removing an unnecessary dict merge and avoiding looping through parts without flows (which would be almost all the parts).

I profiled this by running test_defaults, but with 10,000 steps instead of 100. It went from taking 45 seconds to 35 seconds, which is kind of crazy. We'll see how much it helps for other configurations.